### PR TITLE
Use modularized distribution passagemath-symbolics

### DIFF
--- a/_doctest_environment.py
+++ b/_doctest_environment.py
@@ -1,0 +1,4 @@
+# Toplevel for doctesting with passagemath
+
+from sage.all__sagemath_symbolics import *
+from sage.all__sagemath_plot import *

--- a/setup.py
+++ b/setup.py
@@ -46,4 +46,5 @@ setup(
     package_data={'kerrgeodesic_gw': ['data/*.dat']},
     cmdclass={'test': SageTest}, # adding a special setup command for tests
     install_requires=['sphinx'],
+    extras_require={'passagemath': ['passagemath-symbolics[plot,test]']},
 )

--- a/tox.ini
+++ b/tox.ini
@@ -1,0 +1,13 @@
+[tox]
+envlist = passagemath
+
+[testenv:passagemath]
+usedevelop = True
+extras = passagemath
+
+setenv =
+    # For access to _doctest_environment.py
+    PYTHONPATH=.
+
+commands =
+    sage -tp --environment=_doctest_environment kerrgeodesic_gw


### PR DESCRIPTION
It is now possible to run kerrgeodesic_gw without first installing Sage, by using the modularized distributions from https://github.com/passagemath instead.

With the change in this PR, it will be possible to install the package using just `pip install kerrgeodesic_gw[passagemath]`. The "extra" (optional dependency) `passagemath` is defined in `setup.py`.

For local testing, the PR is adding a `tox.ini` file. Type `tox` to run the tests.
